### PR TITLE
build.gradleの設定追加、受講生情報と受講生コース情報のRead処理を実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,12 @@ java {
 	}
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -23,8 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.apache.commons:commons-lang3'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/raisetech/student_management/Student.java
+++ b/src/main/java/raisetech/student_management/Student.java
@@ -1,0 +1,20 @@
+package raisetech.student_management;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Student {
+  private Integer id;
+  private String name;
+  private String nameKana;
+  private String nickname;
+  private String email;
+  private String area;
+  private LocalDate birthDate;
+  private String gender;
+}

--- a/src/main/java/raisetech/student_management/StudentCourse.java
+++ b/src/main/java/raisetech/student_management/StudentCourse.java
@@ -1,0 +1,17 @@
+package raisetech.student_management;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class StudentCourse {
+  private Integer id;
+  private Integer studentId;
+  private String courseName;
+  private LocalDate startDate;
+  private LocalDate expectedEndDate;
+}

--- a/src/main/java/raisetech/student_management/StudentManagementApplication.java
+++ b/src/main/java/raisetech/student_management/StudentManagementApplication.java
@@ -1,5 +1,6 @@
 package raisetech.student_management;
 
+import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,13 +10,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class StudentManagementApplication {
 
+	private final StudentRepository studentRepository;
+
+	public StudentManagementApplication(StudentRepository studentRepository) {
+		this.studentRepository = studentRepository;
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(StudentManagementApplication.class, args);
 	}
 
-	@GetMapping("/hello")
-	public String hello() {
-		return "Hello World!";
+	/**
+	 * 受講生情報を全件取得して返す
+	 *
+	 * @return Studentのリスト
+	 */
+	@GetMapping("/students")
+	public List<Student> getStudents() {
+		return  studentRepository.findAllStudents();
+	}
+
+	/**
+	 * 受講生コース情報を全件取得して返す
+	 *
+	 * @return StudentCourseのリスト
+	 */
+	@GetMapping("/student-courses")
+	public List<StudentCourse> getStudentCourses() {
+		return  studentRepository.findAllStudentCourses();
 	}
 
 }

--- a/src/main/java/raisetech/student_management/StudentRepository.java
+++ b/src/main/java/raisetech/student_management/StudentRepository.java
@@ -1,0 +1,26 @@
+package raisetech.student_management;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface StudentRepository {
+
+  /**
+   * 受講生情報を全件取得する
+   *
+   * @return Studentのリスト
+   */
+  @Select("SELECT * FROM students")
+  List<Student> findAllStudents();
+
+  /**
+   * 受講生コース情報を全件取得する
+   *
+   * @return StudentCourseのリスト
+   */
+  @Select("SELECT * FROM students_courses")
+  List<StudentCourse> findAllStudentCourses();
+
+}


### PR DESCRIPTION
## 課題
- 受講生情報と受講生コース情報のRead処理を実装した

## 動作確認
### 1-1. studentsテーブル
<img width="903" height="156" alt="スクリーンショット 2025-10-01 1 21 39" src="https://github.com/user-attachments/assets/86ed2e9a-f8ec-4c08-89b9-ecc76a062f4f" />

### 1-2. 受講生情報の取得結果
<img width="1382" height="66" alt="スクリーンショット 2025-10-01 1 46 39" src="https://github.com/user-attachments/assets/ee282538-6792-4cd3-8721-372a2397eecc" />

### 2-1. students_coursesテーブル
<img width="591" height="157" alt="スクリーンショット 2025-10-01 1 23 24" src="https://github.com/user-attachments/assets/7205b3f9-45ec-43b7-9246-6e5eed5d8958" />

### 2-2. 受講生コース情報の取得結果
<img width="1382" height="51" alt="スクリーンショット 2025-10-01 1 47 08" src="https://github.com/user-attachments/assets/c6238dde-349d-4e24-89a6-a460b8ed44c6" />
